### PR TITLE
fixed the bug which it always prints an error line. 

### DIFF
--- a/src/data_access/FileUserDataAccessObject.java
+++ b/src/data_access/FileUserDataAccessObject.java
@@ -9,6 +9,7 @@ import use_case.Login.LoginDataAccessInterface;
 import use_case.Signup.SignupDataAccessInterface;
 
 import java.io.*;
+import java.util.Objects;
 
 public class FileUserDataAccessObject implements SignupDataAccessInterface,
         LoginDataAccessInterface,
@@ -65,6 +66,9 @@ public class FileUserDataAccessObject implements SignupDataAccessInterface,
 
     @Override
     public String get_username(String user_id) {
+        if (user_id == null || Objects.equals(user_id, "")) {
+            return null;
+        }
 
         OkHttpClient client = new OkHttpClient().newBuilder()
                 .build();


### PR DESCRIPTION
Because the get_username method is trying to see if the user_id we put in has any matching nickname even when there's no input, it always prints an error line saying Failed to login: "User" does not exist. Users are not allowed to signup with an empty user_id. With this implementation, the bug has been fixed. 