### PR TITLE
Solve chat history bug

### DIFF
--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: app.Main
+

--- a/src/app/MenuViewFactory.java
+++ b/src/app/MenuViewFactory.java
@@ -2,7 +2,6 @@ package app;
 
 import data_access.FileChannelDataAccessObject;
 import interface_adapter.Menu.MenuViewModel;
-import interface_adapter.ViewChannel.ViewChannelPresenter;
 import interface_adapter.ViewManagerModel;
 import interface_adapter.create_channel.CreateChannelViewModel;
 import interface_adapter.list_Channel.ListChannelController;
@@ -10,6 +9,7 @@ import interface_adapter.list_Channel.ListChannelPresenter;
 import interface_adapter.list_Channel.ListChannelViewModel;
 import interface_adapter.ViewProfile.ViewProfileViewModel;
 import interface_adapter.viewChannel.ViewChannelController;
+import interface_adapter.viewChannel.ViewChannelPresenter;
 import use_case.GetOperator.GetOperatorDataAccessInterface;
 import use_case.ListChannel.*;
 import use_case.ViewChannel.ViewChannelDataAccessInterface;

--- a/src/interface_adapter/Channel/ChannelViewModel.java
+++ b/src/interface_adapter/Channel/ChannelViewModel.java
@@ -98,5 +98,7 @@ public class ChannelViewModel {
                 formattedDate;
     }
 
+    public void reset() {this.sourceMessageList = new ArrayList<>();}
+
 
 }

--- a/src/interface_adapter/send_message/SendMessagePresenter.java
+++ b/src/interface_adapter/send_message/SendMessagePresenter.java
@@ -29,6 +29,7 @@ public class SendMessagePresenter implements SendMessageOutputBoundary {
     public void receivedmessage(SendMessageOutputdata sendMessageOutputdata) {
         ArrayList<Message> messageList = sendMessageOutputdata.getMessageList();
         long messageTs = 0;
+        System.out.println("presenter called");
 
         for (Message message: messageList) {
             String messageContent = message.getMessage();

--- a/src/interface_adapter/viewChannel/ViewChannelPresenter.java
+++ b/src/interface_adapter/viewChannel/ViewChannelPresenter.java
@@ -1,4 +1,4 @@
-package interface_adapter.ViewChannel;
+package interface_adapter.viewChannel;
 
 import app.ChannelViewFactory;
 import entity.Channel.*;
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 public class ViewChannelPresenter implements ViewChannelOutputBoundary {
 
-    private final ChannelViewModel channelViewModel;
+    private ChannelViewModel channelViewModel;
 
 
     public ViewChannelPresenter(){

--- a/src/use_case/InviteMember/InviteMemberInteractor.java
+++ b/src/use_case/InviteMember/InviteMemberInteractor.java
@@ -15,7 +15,7 @@ public class InviteMemberInteractor implements InviteMemberInputBoundary {
         if(!inviteMemberDataAccessInterface.is_member(inviteMemberInputdata)){
             if(inviteMemberDataAccessInterface.invite(inviteMemberInputdata)) {
                 inviteMemberOutputBoundary.prepareSuccessView(
-                        inviteMemberInputdata.getUser_id() + "is now " +
+                        inviteMemberInputdata.getUser_id() + " is now " +
                                 "in your channel!", inviteMemberInputdata.getUser_id());
             }else {
                 inviteMemberOutputBoundary.prepareFailView("User does not exist.");

--- a/src/view/ChannelView.java
+++ b/src/view/ChannelView.java
@@ -409,6 +409,8 @@
             if (messageUpdateTimer != null) {
                 messageUpdateTimer.stop();
             }
+            this.messageList = new JList<>();
+            channelViewModel.reset();
         }
 
     }

--- a/src/view/MenuView.java
+++ b/src/view/MenuView.java
@@ -1,5 +1,6 @@
 package view;
 
+import app.MenuViewFactory;
 import interface_adapter.Menu.MenuViewModel;
 import interface_adapter.ViewManagerModel;
 import interface_adapter.ViewProfile.ViewProfileState;
@@ -32,7 +33,7 @@ public class MenuView extends JPanel implements ActionListener, PropertyChangeLi
     private final CreateChannelViewModel createChannelViewModel;
     private final ViewProfileViewModel viewProfileViewModel;
 
-    private final ViewChannelController viewChannelController;
+    private ViewChannelController viewChannelController;
 
     private Timer refreshTimer;
     private JButton createChannelButton;
@@ -118,6 +119,7 @@ public class MenuView extends JPanel implements ActionListener, PropertyChangeLi
 
     private void navigateToChannel(String userID, String channelUrl) throws IOException {
         viewChannelController.execute(userID, channelUrl);
+        viewChannelController = MenuViewFactory.createViewChannelController();
 
     }
 


### PR DESCRIPTION
Solve the problem that when close a channel and navigate to another, the problem that the chat history will remain.
This was because all the channel share the same controller, now I reset the controller everytime a new channelview is created/